### PR TITLE
Returns incompatible message if either JSON is root empty array

### DIFF
--- a/compatability.go
+++ b/compatability.go
@@ -7,19 +7,6 @@ import (
 
 type jsonNode map[string]interface{}
 
-// IsCompatible checks that two json strings are structurally the same so that they are compatible. The first string should be your "correct" json, if there are extra fields in B then they will still be seen as compatible
-func IsCompatible(a, b string) (errorMessages map[string]string, err error) {
-
-	aMap, err := getJSONNodeFromString(a)
-	bMap, err := getJSONNodeFromString(b)
-
-	if err != nil {
-		return
-	}
-
-	return isStructurallyTheSame(aMap, bMap, make(map[string]string), "")
-}
-
 var (
 	msgFieldMissing       = "Missing field"
 	msgNotString          = "Field is not a string in other JSON"
@@ -28,7 +15,35 @@ var (
 	msgEmptyArray         = "Array in other JSON is empty so I cant check"
 	msgNotMap             = "Not a map in other JSON"
 	msgDifferentArrayType = "Type of array is different"
+	msgEmptyRootArray = "Empty arrays are not suitable for comparison"
 )
+
+func emptyJSONArrayHandler(parseError error) (errorMessages map[string]string, err error) {
+	if _, ok := parseError.(*emptyJSONArrayError); ok {
+		errorMessages = make(map[string]string)
+		errorMessages["rootArray"] = msgEmptyRootArray
+		return
+	}
+
+	return errorMessages, parseError
+}
+
+// IsCompatible checks that two json strings are structurally the same so that they are compatible. The first string should be your "correct" json, if there are extra fields in B then they will still be seen as compatible
+func IsCompatible(a, b string) (errorMessages map[string]string, err error) {
+	aMap, err := getJSONNodeFromString(a)
+
+	if err != nil {
+		return emptyJSONArrayHandler(err)
+	}
+
+	bMap, err := getJSONNodeFromString(b)
+
+	if err != nil {
+		return emptyJSONArrayHandler(err)
+	}
+
+	return isStructurallyTheSame(aMap, bMap, make(map[string]string), "")
+}
 
 func isStructurallyTheSame(a, b jsonNode, messages map[string]string, baseNode string) (map[string]string, error) {
 	for jsonFieldName, v := range a {

--- a/compatability_test.go
+++ b/compatability_test.go
@@ -115,6 +115,18 @@ func TestEmptyArrayInB(t *testing.T) {
 	assertIncompatible(t, a, b)
 }
 
+func TestEmptyTopLevelArrayInA(t *testing.T) {
+	a := `[]`
+	b := `[{"foo":"bar"}]`
+	assertIncompatible(t, a, b)
+}
+
+func TestEmptyTopLevelArrayInB(t *testing.T) {
+	a := `[{"foo":"bar"}]`
+	b := `[]`
+	assertIncompatible(t, a, b)
+}
+
 func assertCompatible(t *testing.T, a, b string) {
 	if messages, err := IsCompatible(a, b); len(messages) > 0 || err != nil {
 		t.Errorf("%s should be compatible with %s (err = %v)", a, b, err)

--- a/json.go
+++ b/json.go
@@ -11,7 +11,19 @@ func getJSONNodeFromString(data string) (node jsonNode, err error) {
 		if err = json.Unmarshal([]byte(data), &anArr); err != nil {
 			return
 		}
-		node = anArr[0]
+
+		if len(anArr) > 0 {
+			node = anArr[0]
+		} else {
+			err = new(emptyJSONArrayError)
+		}
+
 	}
 	return
+}
+
+type emptyJSONArrayError struct{}
+
+func (e *emptyJSONArrayError) Error() string {
+	return "Empty arrays are not suitable for comparison"
 }

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,11 @@
+package jsonequaliser
+
+import "testing"
+
+func TestEmptyJSONArray(t *testing.T) {
+	_, err := getJSONNodeFromString("[]")
+
+	if _, ok := err.(*emptyJSONArrayError); !ok {
+		t.Fatal("Expected an emptyJSONArrayError")
+	}
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -72,6 +72,12 @@ func TestItReportsNonFloats(t *testing.T) {
 	assertMessage(t, A, B, "x", msgNotFloat)
 }
 
+func TestItReportsEmptyArrays(t *testing.T) {
+	A := `[]`
+	B := `[]`
+	assertMessage(t, A, B, "rootArray", msgEmptyRootArray)
+}
+
 func assertMessage(t *testing.T, a, b, key, expectedMessage string) {
 	messages, err := IsCompatible(a, b)
 


### PR DESCRIPTION
This _might_ fix the bug with Mockingjay. Hard to say without seeing the real JSON response, but seems most likely that it is getting an empty array back.